### PR TITLE
First commit to support circular locations

### DIFF
--- a/api/src/refget/main.py
+++ b/api/src/refget/main.py
@@ -417,9 +417,7 @@ async def service_info() -> RefgetServiceInfo:
     Retrieve a RefgetServiceInfo describing the features this API deployment supports.
     """
     return RefgetServiceInfo(
-        refget=Refget(
-            circular_supported=True, algorithms=["md5", "ga4gh", "trunc512"]
-        ),
+        refget=Refget(circular_supported=True, algorithms=["md5", "ga4gh", "trunc512"]),
         id="refget.infra.ebi.ac.uk",
         name="Refget server",
         type=ServiceType(group="org.ga4gh", artifact="refget", version="2.0.0"),


### PR DESCRIPTION
- Changed read_zstd() to work off an interable set of regions
- sequence() assumes all regions can be requested as circular (no metadata available to check otherwise)
- sequence() splits ori spans into two region requests
- Non-circular requests now create an array of one request

Areas to improve

1. Check that this is a valid circular request using metadata about the sequence
2. Check the request is really working as expected

https://compliancedoc.readthedocs.io/en/latest/GET_sequence_API/success/ provides the refget compliance tests and (see case 4) where 3332ed720ac7eaa9b3655c06f6b9e196 is used as the circular region. Request of that region 5374-5 produces the sequence ATCCAACCTGCAGAGTT (length 17).

Added tests for badly formatted range requests which does return 416. Though note spec says "Bad Request error if one or more ranges are out of bounds of the sequence" 416 is intended as the response.